### PR TITLE
Feature/update functorch

### DIFF
--- a/fwdgrad/loss.py
+++ b/fwdgrad/loss.py
@@ -3,29 +3,24 @@ from typing import Callable, Tuple
 import torch
 from torch.nn import functional as F
 
-from fwdgrad.activation import softmax
-from fwdgrad.utils import clamp_probs
 
-
-def _xent(x: torch.Tensor, t: torch.Tensor, num_classes: int = 10) -> torch.Tensor:
+def _xent(x: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
     """Compute cross-entropy loss.
 
     Args:
         x (torch.Tensor): Output of the model.
         t (torch.Tensor): Targets.
-        num_classes (int, optional): Maximum number of classes. Defaults to 10.
-
+        
     Returns:
         torch.Tensor: Cross-entropy loss.
     """
-    y = clamp_probs(softmax(x))
-    logy = -torch.log(y)
-    loss = torch.mean(torch.sum(logy * F.one_hot(t, num_classes), dim=1))
+    y = F.softmax(x, dim=-1)
+    loss = F.cross_entropy(y, t)
     return loss
 
 
 def xent(
-    model: torch.nn.Module, x: torch.Tensor, t: torch.Tensor, num_classes: int = 10
+    model: torch.nn.Module, x: torch.Tensor, t: torch.Tensor
 ) -> torch.Tensor:
     """Cross-entropy loss. Given a pytorch model, it computes the cross-entropy loss.
 
@@ -33,13 +28,12 @@ def xent(
         model (torch.nn.Module): PyTorch model.
         x (torch.Tensor): Input tensor for the PyTorch model.
         t (torch.Tensor): Targets.
-        num_classes (int, optional): Maximum number of classes. Defaults to 10.
 
     Returns:
         torch.Tensor: Cross-entropy loss.
     """
     y = model(x)
-    return _xent(y, t, num_classes)
+    return _xent(y, t)
 
 
 def functional_xent(
@@ -47,7 +41,6 @@ def functional_xent(
     model: Callable[[Tuple[torch.nn.Parameter, ...], torch.Tensor], torch.Tensor],
     x: torch.Tensor,
     t: torch.Tensor,
-    num_classes: int = 10,
 ) -> torch.Tensor:
     """Functional cross-entropy loss. Given a functional version of a pytorch model, which can be obtained with
     `fmodel, params = functorch.make_functional(model)`, it computes the cross-entropy loss.
@@ -58,10 +51,9 @@ def functional_xent(
             obtained by fmodel, `params = fc.make_functional(model)`
         x (torch.Tensor): Input tensor for the PyTorch model.
         t (torch.Tensor): Targets.
-        num_classes (int, optional): Maximum number of classes. Defaults to 10.
 
     Returns:
         torch.Tensor: Cross-entropy loss.
     """
     y = model(params, x)
-    return _xent(y, t, num_classes)
+    return _xent(y, t)

--- a/mnist_fwdgrad.py
+++ b/mnist_fwdgrad.py
@@ -3,10 +3,10 @@ import time
 from functools import partial
 
 import functorch as fc
+import hydra
 import torch
 import torchvision
-
-import hydra
+from functorch import make_functional
 from omegaconf import DictConfig
 
 from fwdgrad.loss import functional_xent
@@ -14,8 +14,13 @@ from fwdgrad.loss import functional_xent
 
 @hydra.main(config_path="./configs/", config_name="config.yaml")
 def train_model(cfg: DictConfig):
-    USE_CUDA = torch.cuda.is_available()
-    DEVICE = torch.device(f"cuda:{cfg.device_id}" if USE_CUDA else "cpu")
+    use_cuda = torch.cuda.is_available()
+    device = torch.device(f"cuda:{cfg.device_id}" if use_cuda else "cpu")
+    total_epochs = cfg.optimization.epochs
+    init_lr = cfg.optimization.learning_rate
+    k = cfg.optimization.k
+    
+    # Dataset creation
     if "NeuralNet" in cfg.model._target_:
         mnist = torchvision.datasets.MNIST(
             "/tmp/data",
@@ -37,21 +42,20 @@ def train_model(cfg: DictConfig):
             transform=torchvision.transforms.Compose([torchvision.transforms.ToTensor()]),
         )
         input_size = 1  # Channel size
-
     train_loader = hydra.utils.instantiate(cfg.dataset, dataset=mnist)
 
     output_size = len(mnist.classes)
     with torch.no_grad():
         model = hydra.utils.instantiate(cfg.model, input_size=input_size, output_size=output_size)
-        model.to(DEVICE)
+        model.to(device)
         model.float()
         model.train()
 
         # Get the functional version of the model with functorch
-        fmodel, params = fc.make_functional(model)
+        fmodel, params = make_functional(model)
 
         t_total = 0
-        for epoch in range(cfg.optimization.epochs):
+        for epoch in range(total_epochs):
             t0 = time.perf_counter()
             for i, batch in enumerate(train_loader):
                 images, labels = batch
@@ -61,21 +65,21 @@ def train_model(cfg: DictConfig):
                 f = partial(
                     functional_xent,
                     model=fmodel,
-                    x=images.to(DEVICE),
-                    t=labels.to(DEVICE),
+                    x=images.to(device),
+                    t=labels.to(device),
                 )
 
                 # Forward AD
                 loss, jvp = fc.jvp(f, (tuple(params),), (v_params,))
 
                 # Forward gradient + parmeter update (SGD)
-                lr = cfg.optimization.learning_rate * math.e ** (-(epoch * len(train_loader) + i) * cfg.optimization.k)
+                lr = init_lr * math.e ** (-(epoch * len(train_loader) + i) * k)
                 for j, p in enumerate(params):
                     p.sub_(lr * jvp * v_params[j])
             t1 = time.perf_counter()
             t_total += t1 - t0
-            print(f"Epoch [{epoch+1}/{cfg.optimization.epochs}], Loss: {loss.item():.4f}, Time (s): {t1 - t0:.4f}")
-        print(f"Mean time: {t_total / cfg.optimization.epochs:.4f}")
+            print(f"Epoch [{epoch+1}/{total_epochs}], Loss: {loss.item():.4f}, Time (s): {t1 - t0:.4f}")
+        print(f"Mean time: {t_total / total_epochs:.4f}")
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 torch>=1.11
 torchvision>=0.12
-functorch>=0.1
 omegaconf~=2.1.2
 hydra-core==1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch>=1.11
-torchvision>=0.12
+torch>=1.13
+torchvision>=0.14
 omegaconf~=2.1.2
 hydra-core==1.1.2


### PR DESCRIPTION
Update functorch version: now installing PyTorch >= 1.13 is enough to have functorch installed.
This lets us use standard PyTorch function instead of custom ones, like softmax and cross-entropy